### PR TITLE
Support removing trends widgets without cogwheel

### DIFF
--- a/hide-twitter-trends.js
+++ b/hide-twitter-trends.js
@@ -6,6 +6,12 @@
  * then look at some of the neighboring DOM trying to reduce false positives.
  * (The many class names on the elements don’t look stable,
  * so we only match on element names, hoping they’re more reliable.)
+ *
+ * There is also a version of the Trends widget without the cogwheel.
+ * We can try to identify this using the “trending with…” links,
+ * which, if they exist, have &src=trend_click in the URL.
+ * (The actual trends themselves aren’t links at all, but divs with event handlers.)
+ * If none of the trends are “trending with” something, we’re out of luck.
  */
 function removeTrends() {
     for (let trends of document.querySelectorAll('a[href="/settings/trends"]')) {
@@ -16,6 +22,29 @@ function removeTrends() {
         trends = trends.closest('h2');
         if (!trends) {
             // trends link in settings? maybe?
+            continue;
+        }
+        trends = trends.closest('section');
+        if (!trends) {
+            // (unclear if this can happen)
+            continue;
+        }
+        if (trends.firstElementChild.tagName !== 'H1') {
+            // (unclear if this can happen)
+            continue;
+        }
+        let parent;
+        while ((parent = trends.parentElement).childElementCount == 1)
+            trends = parent;
+        trends.remove();
+    }
+    for (let trends of document.querySelectorAll('a[href*="&src=trend_click"]')) {
+        if (!document.body.contains(trends)) {
+            // we already removed the parent trends widget
+            continue;
+        }
+        if (trends.closest('article')) {
+            // trends link in a tweet
             continue;
         }
         trends = trends.closest('section');


### PR DESCRIPTION
Some users are reporting a version of the trends widget without the cogwheel link. We can try to identify this version (also the other version, but let’s keep the old code for that) using the “trending with…” links under some trends, which, if they exist, identify the source via some URL parameters.